### PR TITLE
Add additional debugging output

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,18 @@ import SettingsApp from './lib/settings'
  */
 export default (robot, _, Settings = SettingsApp) => {
   async function syncSettings (context, repo = context.repo()) {
+    const { host } = context
+    const { GHE_HOST } = process.env
+    if (host === 'github.com' && GHE_HOST) {
+      robot.log.warn('Webhook source is public github, but GHE_HOST is set. Settings may not be read correctly.')
+    }
+    else if (host !== GHE_HOST) {
+      robot.log.warn('Webhook source does not match GHE_HOST. Settings may not be read correctly.')
+    }
+
     const config = await context.config('settings.yml', {}, { arrayMerge: mergeArrayByName })
     if (!config || !Object.keys(config).length) {
-      robot.log.debug(`Unable to read config from '${Settings.FILE_NAME}', returning...`)
+      robot.log.error(`Unable to read config from '${Settings.FILE_NAME}'`)
       return
     }
     const results = Settings.sync(context.octokit, repo, config)

--- a/index.js
+++ b/index.js
@@ -7,7 +7,13 @@ import SettingsApp from './lib/settings'
 export default (robot, _, Settings = SettingsApp) => {
   async function syncSettings (context, repo = context.repo()) {
     const config = await context.config('settings.yml', {}, { arrayMerge: mergeArrayByName })
-    return Settings.sync(context.octokit, repo, config)
+    if (!config || !Object.keys(config).length) {
+      robot.log.debug(`Unable to read config from '${Settings.FILE_NAME}', returning...`)
+      return
+    }
+    const results = Settings.sync(context.octokit, repo, config)
+    robot.log.debug('Synced settings')
+    return results
   }
 
   robot.on('push', async context => {


### PR DESCRIPTION
This PR adds some debugging output for when `context.config` returns an empty object (or `null`). This resulted from #566, where I had neglected to set `GHE_HOST` so Octokit called public Github instead of GHE. Hopefully this debugging helps future users identify the same situation.