### PR TITLE
ci: updated the repo name to match the recent update

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,5 +1,5 @@
 repository:
-  name: settings
+  name: app
   description: Pull Requests for GitHub repository settings
   homepage: https://github.com/apps/settings
   topics: probot-app, github-app


### PR DESCRIPTION
i figure that we should activate the app on our own repo again, but we need this to be up to date before that, so the repo doesnt get renamed