### PR TITLE
ci(release): re-enabled the success comment

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,6 +2,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/github", {"successComment": false}]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
since we only intended to disable for the initial release