### PR TITLE
Fix an error that does not accept 4-byte Unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ repository:
 labels:
   - name: bug
     color: CC0000
-    description: An issue with the system 🐛.
+    description: An issue with the system.
 
   - name: feature
     # If including a `#`, make sure to wrap it with quotes!


### PR DESCRIPTION
I copied template setting in README and run an application.
But I got an error like below.
```
{"resource":"Label","code":"custom","field":"description","message":"description doesn't accept 4-byte Unicode"}
```

So I remove 🐛 from template setting.