### PR TITLE
User proper role names

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ collaborators:
 teams:
   - name: core
     # The permission to grant the team. Can be one of:
-    # * `pull` - can pull, but not push to or administer this repository.
-    # * `push` - can pull and push, but not administer this repository.
+    # * `read` - can pull, but not push to or administer this repository.
+    # * `write` - can pull and push, but not administer this repository.
     # * `admin` - can pull, push and administer this repository.
     # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
     # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ milestones:
 # See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
 collaborators:
   # - username: bkeepers
-  #   permission: write
+  #   permission: push
   # - username: hubot
-  #   permission: read
+  #   permission: pull
 
   # Note: `permission` is only valid on organization-owned repositories.
   # The permission to grant the collaborator. Can be one of:
-  # * `read` - can pull, but not push to or administer this repository.
-  # * `write` - can pull and push, but not administer this repository.
+  # * `pull` - can pull, but not push to or administer this repository.
+  # * `push` - can pull and push, but not administer this repository.
   # * `admin` - can pull, push and administer this repository.
   # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
   # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ teams:
     # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
     permission: admin
   - name: docs
-    permission: push
+    permission: write
 
 branches:
   - name: master

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ milestones:
 # See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
 collaborators:
   # - username: bkeepers
-  #   permission: push
+  #   permission: write
   # - username: hubot
-  #   permission: pull
+  #   permission: read
 
   # Note: `permission` is only valid on organization-owned repositories.
   # The permission to grant the collaborator. Can be one of:
-  # * `pull` - can pull, but not push to or administer this repository.
-  # * `push` - can pull and push, but not administer this repository.
+  # * `read` - can pull, but not push to or administer this repository.
+  # * `write` - can pull and push, but not administer this repository.
   # * `admin` - can pull, push and administer this repository.
   # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
   # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.


### PR DESCRIPTION
I am not sure if this changed at some point in the past, but pull and push should be read and write, respectively: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization

I've ran across some confusion due to this README referencing pull and push, so I figured it should be updated 😊

GitHub's own documentation around this is murky as some pages state 'write' and 'read', while others state 'push' and 'pull'...