### PR TITLE
Clarify Permissions in `deploy.md`

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -6,7 +6,7 @@ If you would like to run your own instance of this plugin, see the [docs for dep
 
 This plugin requires these **Permissions & events** for the GitHub Integration:
 
-### Permissions
+### Repository Permissions
 
 - Administration: **Read & Write**
 - Contents: **Read only**


### PR DESCRIPTION
Just a minor doc tweak to be explicit about the `Repository Permissions` section.