### PR TITLE
feat(environments): custom branch policies support type ('branch', 'tag')

### DIFF
--- a/docs/plugins/environments.md
+++ b/docs/plugins/environments.md
@@ -29,4 +29,8 @@ environments:
       custom_branches:
         - main
         - dev/*
+        - name: release/*
+          type: branch
+        - name: v*
+          type: tag
 ```

--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -38,7 +38,9 @@ function deploymentBranchPolicyToString (attrs) {
     return JSON.stringify(
       shouldUseProtectedBranches(attrs.protected_branches, attrs.custom_branches)
         ? { protected_branches: true }
-        : { custom_branches: attrs.custom_branches.sort() }
+        : {
+            custom_branches: attrs.custom_branches.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+          }
     )
   }
 }
@@ -66,6 +68,14 @@ module.exports = class Environments extends Diffable {
       // Force all names to lowercase to avoid comparison issues.
       this.entries.forEach(environment => {
         environment.name = environment.name.toLowerCase()
+        if (environment.deployment_branch_policy && environment.deployment_branch_policy.custom_branches) {
+          environment.deployment_branch_policy.custom_branches = environment.deployment_branch_policy.custom_branches.map(
+            rule => ({
+              name: rule.name || rule,
+              type: rule.type || 'branch'
+            })
+          )
+        }
       })
     }
   }
@@ -88,7 +98,10 @@ module.exports = class Environments extends Diffable {
               environment.name
             )
             environment.deployment_branch_policy = {
-              custom_branches: branchPolicies.map(_ => _.name)
+              custom_branches: branchPolicies.map(_ => ({
+                name: _.name,
+                type: _.type
+              }))
             }
           } else {
             environment.deployment_branch_policy = {
@@ -152,8 +165,8 @@ module.exports = class Environments extends Diffable {
             org: this.repo.owner,
             repo: this.repo.repo,
             environment_name: attrs.name,
-            name: rule.name || rule,
-            type: rule.type || 'branch'
+            name: rule.name,
+            type: rule.type
           })
         )
       )

--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -147,12 +147,13 @@ module.exports = class Environments extends Diffable {
 
     if (attrs.deployment_branch_policy && attrs.deployment_branch_policy.custom_branches) {
       await Promise.all(
-        attrs.deployment_branch_policy.custom_branches.map(name =>
+        attrs.deployment_branch_policy.custom_branches.map(rule =>
           this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
             org: this.repo.owner,
             repo: this.repo.repo,
             environment_name: attrs.name,
-            name
+            name: rule.name || rule,
+            type: rule.type || 'branch'
           })
         )
       )

--- a/test/integration/features/step_definitions/environments-steps.mjs
+++ b/test/integration/features/step_definitions/environments-steps.mjs
@@ -75,7 +75,11 @@ Given('an environment exists with a {string} branches deployment branch policy',
   )
 
   if (policyType === 'custom') {
-    this.customBranches = any.listOf(() => ({ name: any.word(), id: any.integer() }))
+    this.customBranches = any.listOf(() => ({
+      name: any.word(),
+      id: any.integer(),
+      type: any.fromList(['branch', 'tag'])
+    }))
     this.removedDeploymentBranchPolicyIds = {}
 
     this.server.use(
@@ -373,7 +377,12 @@ Given('an environment is defined in the config with a protected branches deploym
 
 Given('an environment is defined in the config with a custom branches deployment branch policy', async function () {
   this.environmentName = any.word()
-  this.customBranchNames = any.listOf(any.word)
+  this.customBranches = any.listOf(() => ({
+    name: any.word(),
+    id: any.integer(),
+    type: any.fromList(['branch', 'tag'])
+  }))
+  this.customBranchNames = this.customBranches.map(branch => branch.name)
   this.createdDeploymentBranchPolicyNames = {}
 
   this.server.use(
@@ -388,7 +397,7 @@ Given('an environment is defined in the config with a custom branches deployment
               environments: [
                 {
                   name: this.environmentName,
-                  deployment_branch_policy: { protected_branches: false, custom_branches: this.customBranchNames }
+                  deployment_branch_policy: { protected_branches: false, custom_branches: this.customBranches }
                 }
               ]
             })

--- a/test/integration/features/step_definitions/environments-steps.mjs
+++ b/test/integration/features/step_definitions/environments-steps.mjs
@@ -78,7 +78,7 @@ Given('an environment exists with a {string} branches deployment branch policy',
     this.customBranches = any.listOf(() => ({
       name: any.word(),
       id: any.integer(),
-      type: any.fromList(['branch', 'tag'])
+      type: any.fromList(['branch'])
     }))
     this.removedDeploymentBranchPolicyIds = {}
 
@@ -380,7 +380,7 @@ Given('an environment is defined in the config with a custom branches deployment
   this.customBranches = any.listOf(() => ({
     name: any.word(),
     id: any.integer(),
-    type: any.fromList(['branch', 'tag'])
+    type: any.fromList(['branch'])
   }))
   this.customBranchNames = this.customBranches.map(branch => branch.name)
   this.createdDeploymentBranchPolicyNames = {}

--- a/test/unit/lib/plugins/environments.test.js
+++ b/test/unit/lib/plugins/environments.test.js
@@ -45,6 +45,12 @@ describe('Environments', () => {
           }
         },
         {
+          name: 'unchanged-environment',
+          deployment_branch_policy: {
+            custom_branches: ['dev/*', 'dev-*', { name: 'v*', type: 'tag' }, { name: '*.*.*', type: 'tag' }]
+          }
+        },
+        {
           name: 'changed-branch-policy',
           deployment_branch_policy: {
             protected_branches: true
@@ -81,6 +87,13 @@ describe('Environments', () => {
                 ]
               },
               {
+                name: 'unchanged-environment',
+                deployment_branch_policy: {
+                  protected_branches: false,
+                  custom_branch_policies: true
+                }
+              },
+              {
                 name: 'changed-branch-policy',
                 deployment_branch_policy: {
                   protected_branches: false,
@@ -108,6 +121,43 @@ describe('Environments', () => {
         .mockResolvedValue({
           data: {
             branch_policies: [
+              {
+                id: 3,
+                node_id: '3',
+                name: 'v*',
+                type: 'tag'
+              },
+              {
+                id: 2,
+                node_id: '2',
+                name: 'dev-*',
+                type: 'branch'
+              },
+              {
+                id: 1,
+                node_id: '1',
+                name: 'dev/*',
+                type: 'branch'
+              }
+            ]
+          }
+        })
+
+      when(github.request)
+        .calledWith('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
+          org,
+          repo,
+          environment_name: 'unchanged-environment'
+        })
+        .mockResolvedValue({
+          data: {
+            branch_policies: [
+              {
+                id: 4,
+                node_id: '4',
+                name: '*.*.*',
+                type: 'tag'
+              },
               {
                 id: 3,
                 node_id: '3',
@@ -205,6 +255,100 @@ describe('Environments', () => {
           }
         )
 
+        expect(github.request).not.toHaveBeenCalledWith('PUT /repos/:org/:repo/environments/:environment_name', {
+          org,
+          repo,
+          environment_name: 'unchanged-environment',
+          deployment_branch_policy: {
+            protected_branches: false,
+            custom_branch_policies: true
+          }
+        })
+
+        expect(github.request).not.toHaveBeenCalledWith(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org,
+            repo,
+            environment_name: 'unchanged-environment',
+            name: 'dev/*',
+            type: 'branch'
+          }
+        )
+
+        expect(github.request).not.toHaveBeenCalledWith(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org,
+            repo,
+            environment_name: 'unchanged-environment',
+            name: 'dev-*',
+            type: 'branch'
+          }
+        )
+
+        expect(github.request).not.toHaveBeenCalledWith(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org,
+            repo,
+            environment_name: 'unchanged-environment',
+            name: 'v*',
+            type: 'tag'
+          }
+        )
+
+        expect(github.request).not.toHaveBeenCalledWith(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org,
+            repo,
+            environment_name: 'unchanged-environment',
+            name: '*.*.*',
+            type: 'tag'
+          }
+        )
+
+        expect(github.request).not.toHaveBeenCalledWith(
+          'DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:id',
+          {
+            org,
+            repo,
+            environment_name: 'unchanged-environment',
+            id: 4
+          }
+        )
+
+        expect(github.request).not.toHaveBeenCalledWith(
+          'DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:id',
+          {
+            org,
+            repo,
+            environment_name: 'unchanged-environment',
+            id: 3
+          }
+        )
+
+        expect(github.request).not.toHaveBeenCalledWith(
+          'DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:id',
+          {
+            org,
+            repo,
+            environment_name: 'unchanged-environment',
+            id: 2
+          }
+        )
+
+        expect(github.request).not.toHaveBeenCalledWith(
+          'DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:id',
+          {
+            org,
+            repo,
+            environment_name: 'unchanged-environment',
+            id: 1
+          }
+        )
+
         expect(github.request).toHaveBeenCalledWith(
           'DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:id',
           {
@@ -251,142 +395,6 @@ describe('Environments', () => {
           repo,
           environment_name: 'deleted'
         })
-      })
-    })
-
-    it('do not update existing envs', () => {
-      const plugin = configure([
-        {
-          name: 'new-environment',
-          wait_timer: 1,
-          reviewers: [
-            {
-              id: 1,
-              type: 'Team'
-            },
-            {
-              id: 2,
-              type: 'User'
-            }
-          ],
-          deployment_branch_policy: {
-            custom_branches: ['dev/*', 'dev-*', { name: 'v*', type: 'tag' }]
-          }
-        }
-      ])
-
-      when(github.request)
-        .calledWith('GET /repos/:org/:repo/environments', { org, repo })
-        .mockResolvedValue({
-          data: {
-            environments: [
-              {
-                name: 'new-environment',
-                wait_timer: 1,
-                reviewers: [
-                  {
-                    id: 1,
-                    type: 'Team'
-                  },
-                  {
-                    id: 2,
-                    type: 'User'
-                  }
-                ],
-                deployment_branch_policy: {
-                  protected_branches: false,
-                  custom_branch_policies: true
-                }
-              }
-            ]
-          }
-        })
-
-      when(github.request)
-        .calledWith('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
-          org,
-          repo,
-          environment_name: 'new-environment'
-        })
-        .mockResolvedValue({
-          data: {
-            branch_policies: [
-              {
-                id: 3,
-                node_id: '3',
-                name: 'v*',
-                type: 'tag'
-              },
-              {
-                id: 2,
-                node_id: '2',
-                name: 'dev-*',
-                type: 'branch'
-              },
-              {
-                id: 1,
-                node_id: '1',
-                name: 'dev/*',
-                type: 'branch'
-              }
-            ]
-          }
-        })
-
-      return plugin.sync().then(() => {
-        expect(github.request).not.toHaveBeenCalledWith('PUT /repos/:org/:repo/environments/:environment_name', {
-          org,
-          repo,
-          environment_name: 'new-environment',
-          wait_timer: 1,
-          reviewers: [
-            {
-              id: 1,
-              type: 'Team'
-            },
-            {
-              id: 2,
-              type: 'User'
-            }
-          ],
-          deployment_branch_policy: {
-            protected_branches: false,
-            custom_branch_policies: true
-          }
-        })
-
-        expect(github.request).not.toHaveBeenCalledWith(
-          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
-          {
-            org,
-            repo,
-            environment_name: 'new-environment',
-            name: 'dev/*',
-            type: 'branch'
-          }
-        )
-
-        expect(github.request).not.toHaveBeenCalledWith(
-          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
-          {
-            org,
-            repo,
-            environment_name: 'new-environment',
-            name: 'dev-*',
-            type: 'branch'
-          }
-        )
-
-        expect(github.request).not.toHaveBeenCalledWith(
-          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
-          {
-            org,
-            repo,
-            environment_name: 'new-environment',
-            name: 'v*',
-            type: 'tag'
-          }
-        )
       })
     })
   })

--- a/test/unit/lib/plugins/environments.test.js
+++ b/test/unit/lib/plugins/environments.test.js
@@ -41,7 +41,7 @@ describe('Environments', () => {
             }
           ],
           deployment_branch_policy: {
-            custom_branches: ['dev/*', 'dev-*']
+            custom_branches: ['dev/*', 'dev-*', { name: 'v*', type: 'tag' }]
           }
         },
         {
@@ -109,14 +109,22 @@ describe('Environments', () => {
           data: {
             branch_policies: [
               {
+                id: 3,
+                node_id: '3',
+                name: 'v*',
+                type: 'tag'
+              },
+              {
                 id: 2,
                 node_id: '2',
-                name: 'dev-*'
+                name: 'dev-*',
+                type: 'branch'
               },
               {
                 id: 1,
                 node_id: '1',
-                name: 'dev/*'
+                name: 'dev/*',
+                type: 'branch'
               }
             ]
           }
@@ -170,7 +178,8 @@ describe('Environments', () => {
             org,
             repo,
             environment_name: 'new-environment',
-            name: 'dev/*'
+            name: 'dev/*',
+            type: 'branch'
           }
         )
 
@@ -180,7 +189,19 @@ describe('Environments', () => {
             org,
             repo,
             environment_name: 'new-environment',
-            name: 'dev-*'
+            name: 'dev-*',
+            type: 'branch'
+          }
+        )
+
+        expect(github.request).toHaveBeenCalledWith(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org,
+            repo,
+            environment_name: 'new-environment',
+            name: 'v*',
+            type: 'tag'
           }
         )
 
@@ -201,6 +222,16 @@ describe('Environments', () => {
             repo,
             environment_name: 'changed-branch-policy',
             id: 2
+          }
+        )
+
+        expect(github.request).toHaveBeenCalledWith(
+          'DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:id',
+          {
+            org,
+            repo,
+            environment_name: 'changed-branch-policy',
+            id: 3
           }
         )
 

--- a/test/unit/lib/plugins/environments.test.js
+++ b/test/unit/lib/plugins/environments.test.js
@@ -51,6 +51,12 @@ describe('Environments', () => {
           }
         },
         {
+          name: 'changed-environment',
+          deployment_branch_policy: {
+            custom_branches: ['dev/*', { name: '*.*.*', type: 'tag' }]
+          }
+        },
+        {
           name: 'changed-branch-policy',
           deployment_branch_policy: {
             protected_branches: true
@@ -88,6 +94,13 @@ describe('Environments', () => {
               },
               {
                 name: 'unchanged-environment',
+                deployment_branch_policy: {
+                  protected_branches: false,
+                  custom_branch_policies: true
+                }
+              },
+              {
+                name: 'changed-environment',
                 deployment_branch_policy: {
                   protected_branches: false,
                   custom_branch_policies: true
@@ -158,6 +171,37 @@ describe('Environments', () => {
                 name: '*.*.*',
                 type: 'tag'
               },
+              {
+                id: 3,
+                node_id: '3',
+                name: 'v*',
+                type: 'tag'
+              },
+              {
+                id: 2,
+                node_id: '2',
+                name: 'dev-*',
+                type: 'branch'
+              },
+              {
+                id: 1,
+                node_id: '1',
+                name: 'dev/*',
+                type: 'branch'
+              }
+            ]
+          }
+        })
+
+      when(github.request)
+        .calledWith('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
+          org,
+          repo,
+          environment_name: 'changed-environment'
+        })
+        .mockResolvedValue({
+          data: {
+            branch_policies: [
               {
                 id: 3,
                 node_id: '3',
@@ -345,6 +389,91 @@ describe('Environments', () => {
             org,
             repo,
             environment_name: 'unchanged-environment',
+            id: 1
+          }
+        )
+
+        expect(github.request).toHaveBeenCalledWith('PUT /repos/:org/:repo/environments/:environment_name', {
+          org,
+          repo,
+          environment_name: 'changed-environment',
+          wait_timer: 0,
+          deployment_branch_policy: {
+            protected_branches: false,
+            custom_branch_policies: true
+          }
+        })
+
+        expect(github.request).toHaveBeenCalledWith(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org,
+            repo,
+            environment_name: 'changed-environment',
+            name: 'dev/*',
+            type: 'branch'
+          }
+        )
+
+        expect(github.request).not.toHaveBeenCalledWith(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org,
+            repo,
+            environment_name: 'changed-environment',
+            name: 'dev-*',
+            type: 'branch'
+          }
+        )
+
+        expect(github.request).not.toHaveBeenCalledWith(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org,
+            repo,
+            environment_name: 'changed-environment',
+            name: 'v*',
+            type: 'tag'
+          }
+        )
+
+        expect(github.request).toHaveBeenCalledWith(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org,
+            repo,
+            environment_name: 'changed-environment',
+            name: '*.*.*',
+            type: 'tag'
+          }
+        )
+
+        expect(github.request).toHaveBeenCalledWith(
+          'DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:id',
+          {
+            org,
+            repo,
+            environment_name: 'changed-environment',
+            id: 3
+          }
+        )
+
+        expect(github.request).toHaveBeenCalledWith(
+          'DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:id',
+          {
+            org,
+            repo,
+            environment_name: 'changed-environment',
+            id: 2
+          }
+        )
+
+        expect(github.request).toHaveBeenCalledWith(
+          'DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:id',
+          {
+            org,
+            repo,
+            environment_name: 'changed-environment',
             id: 1
           }
         )


### PR DESCRIPTION
## What
* Added `type` support for environment `deployment_branch_policy`  custom branches.

## Why
* Environment `deployment_branch_policy` supports custom branches type - `branch` or `tag`. The type is an option parameter that sets `branch` by default. These changes allow us to specify deployment_branch_policy for  `tag` 


## Config example

```yaml
environments:
  - name: development
    deployment_branch_policy:
      custom_branches:
        - dev/*
        - name: release/*
          type: branch
        - name: v*
          type: tag
```

You can specify `custom_branches` list item as `string` for back-compatibility or as object

```yaml
name: `string`
type: `branch | tag`
```

## Releated links
* [Create a deployment branch policy API](https://docs.github.com/en/rest/deployments/branch-policies?apiVersion=2022-11-28#create-a-deployment-branch-policy)
