### PR TITLE
docs(rulesets): fix ruleset status checks example

### DIFF
--- a/docs/plugins/rulesets.md
+++ b/docs/plugins/rulesets.md
@@ -34,6 +34,7 @@ rulesets:
     rules:
       - type: required_status_checks
         parameters:
+          strict_required_status_checks_policy: false # Required field
           required_status_checks:
             - context: test
               integration_id: 123456


### PR DESCRIPTION
This commit fixes the example in the ruleset documentation, which was missing the `strict_required_status_checks_policy` key. According to GitHub API documentation[1], this is a required field so it needs to be defined in the configuration file (at least at this point in time).

[1]: https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#create-a-repository-ruleset