### PR TITLE
fix(rulesets): avoid updates when no meaningful change is made

### DIFF
--- a/lib/plugins/rulesets.js
+++ b/lib/plugins/rulesets.js
@@ -18,7 +18,17 @@ export default class Rulesets extends Diffable {
   }
 
   changed (existing, attrs) {
-    const { id, ...existingAttrs } = existing
+    const {
+      id,
+      _links,
+      created_at: createdAt,
+      updated_at: updatedAd,
+      source_type: sourceType,
+      source,
+      node_id: nodeId,
+      current_user_can_bypass: currentUserCanBypass,
+      ...existingAttrs
+    } = existing
 
     return !deepEqual(existingAttrs, attrs)
   }

--- a/test/integration/features/rulesets.feature
+++ b/test/integration/features/rulesets.feature
@@ -17,3 +17,9 @@ Feature: Repository Rulesets
     And the ruleset is removed from the config
     When a settings sync is triggered
     Then the ruleset is deleted
+
+  Scenario: No Updates
+    Given a ruleset exists for the repository
+    And no ruleset updates are made to the config
+    When a settings sync is triggered
+    Then no ruleset updates are triggered


### PR DESCRIPTION
by filtering ruleset state properties from api response that do not get updated from the config

for #732