### PR TITLE
feat: allow `.yaml` extension for the settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Repository Settings
 
-This GitHub App syncs repository settings defined in `.github/settings.yml` to GitHub, enabling Pull Requests for repository settings.
+This GitHub App syncs repository settings defined in `.github/settings.yml` (or `.github/settings.yaml`) to GitHub, enabling Pull Requests for repository settings.
 
 <!--status-badges start -->
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Create a `.github/settings.yml` file in your repository. Changes to this file on the default branch will be synced to GitHub.
+Create a `.github/settings.yml` (or `.github/settings.yaml`) file in your repository. Changes to this file on the default branch will be synced to GitHub. When both files exist, `.github/settings.yml` takes precedence and `.github/settings.yaml` is ignored.
 
 ## Sections
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -86,6 +86,7 @@ This plugin requires these **Permissions & events** for the GitHub Integration:
 - Issues: **Read & Write**
 - Single file: **Read & Write**
   - Path: `.github/settings.yml`
+  - Path: `.github/settings.yaml`
 - Actions: **Read only**
 
 ### Organization Permissions

--- a/index.js
+++ b/index.js
@@ -5,8 +5,21 @@ import SettingsApp from './lib/settings.js'
  * @param {import('probot').Probot} robot
  */
 export default (robot, _, Settings = SettingsApp) => {
+  async function loadConfig (context) {
+    for (const filePath of Settings.FILE_NAMES) {
+      const fileName = filePath.replace(/^\.github\//, '')
+      const config = await context.config(fileName, undefined, { arrayMerge: mergeArrayByName })
+
+      if (config !== null) {
+        return config
+      }
+    }
+
+    return {}
+  }
+
   async function syncSettings (context, repo = context.repo()) {
-    const config = await context.config('settings.yml', {}, { arrayMerge: mergeArrayByName })
+    const config = await loadConfig(context)
     return Settings.sync(context.octokit, repo, config)
   }
 
@@ -21,11 +34,13 @@ export default (robot, _, Settings = SettingsApp) => {
     }
 
     const settingsModified = payload.commits.find(commit => {
-      return commit.added.includes(Settings.FILE_NAME) || commit.modified.includes(Settings.FILE_NAME)
+      return Settings.FILE_NAMES.some(fileName => {
+        return commit.added.includes(fileName) || commit.modified.includes(fileName)
+      })
     })
 
     if (!settingsModified) {
-      robot.log.debug(`No changes in '${Settings.FILE_NAME}' detected, returning...`)
+      robot.log.debug(`No changes in '${Settings.FILE_NAMES.join("', '")}' detected, returning...`)
       return
     }
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -41,7 +41,9 @@ export default class Settings {
   }
 }
 
-Settings.FILE_NAME = '.github/settings.yml'
+Settings.FILE_NAMES = ['.github/settings.yml', '.github/settings.yaml']
+
+Settings.FILE_NAME = Settings.FILE_NAMES[0]
 
 Settings.PLUGINS = {
   repository: Repository,

--- a/test/integration/features/repository.feature
+++ b/test/integration/features/repository.feature
@@ -5,6 +5,11 @@ Feature: Repository
     When a settings sync is triggered
     Then the repository will be configured
 
+  Scenario: Basic repository settings from a settings.yaml file
+    Given basic repository config is defined in a settings.yaml file
+    When a settings sync is triggered
+    Then the repository will be configured
+
   Scenario: Repository with topics defined
     Given topics are defined in the repository config
     When a settings sync is triggered

--- a/test/integration/features/step_definitions/config-steps.js
+++ b/test/integration/features/step_definitions/config-steps.js
@@ -19,22 +19,22 @@ export function buildPushEvent ({ pushBranch } = {}) {
 
 Given('the repository has no settings file', async function () {
   this.server.use(
-    http.get(
-      `https://api.github.com/repos/${repository.owner.name}/${repository.name}/contents/${encodeURIComponent(
-        settings.FILE_NAME
-      )}`,
-      ({ request }) => {
-        return new HttpResponse(null, { status: StatusCodes.NOT_FOUND })
-      }
-    ),
-    http.get(
-      `https://api.github.com/repos/${repository.owner.name}/.github/contents/${encodeURIComponent(
-        settings.FILE_NAME
-      )}`,
-      ({ request }) => {
-        return new HttpResponse(null, { status: StatusCodes.NOT_FOUND })
-      }
-    )
+    ...settings.FILE_NAMES.flatMap(fileName => [
+      http.get(
+        `https://api.github.com/repos/${repository.owner.name}/${repository.name}/contents/${encodeURIComponent(
+          fileName
+        )}`,
+        ({ request }) => {
+          return new HttpResponse(null, { status: StatusCodes.NOT_FOUND })
+        }
+      ),
+      http.get(
+        `https://api.github.com/repos/${repository.owner.name}/.github/contents/${encodeURIComponent(fileName)}`,
+        ({ request }) => {
+          return new HttpResponse(null, { status: StatusCodes.NOT_FOUND })
+        }
+      )
+    ])
   )
 })
 

--- a/test/integration/features/step_definitions/repository-steps.js
+++ b/test/integration/features/step_definitions/repository-steps.js
@@ -33,6 +33,42 @@ Given('basic repository config is defined', async function () {
   )
 })
 
+Given('basic repository config is defined in a settings.yaml file', async function () {
+  this.repository = {
+    name: repository.name,
+    description: any.sentence(),
+    default_branch: 'main',
+    visibility: any.fromList(['public', 'private', 'internal']),
+    homepage: any.url()
+  }
+
+  this.server.use(
+    http.get(
+      `https://api.github.com/repos/${repository.owner.name}/${repository.name}/contents/${encodeURIComponent(
+        settings.FILE_NAMES[0]
+      )}`,
+      () => new HttpResponse(null, { status: StatusCodes.NOT_FOUND })
+    ),
+    http.get(
+      `https://api.github.com/repos/${repository.owner.name}/.github/contents/${encodeURIComponent(
+        settings.FILE_NAMES[0]
+      )}`,
+      () => new HttpResponse(null, { status: StatusCodes.NOT_FOUND })
+    ),
+    http.get(
+      `https://api.github.com/repos/${repository.owner.name}/${repository.name}/contents/${encodeURIComponent(
+        settings.FILE_NAMES[1]
+      )}`,
+      () => HttpResponse.text(dump({ repository: this.repository }))
+    ),
+    http.patch(`https://api.github.com/repos/${repository.owner.name}/${repository.name}`, async ({ request }) => {
+      this.repositoryDetails = await request.json()
+
+      return new HttpResponse(null, { status: StatusCodes.OK })
+    })
+  )
+})
+
 Given('topics are defined in the repository config', async function () {
   this.repository = {
     name: repository.name,

--- a/test/integration/triggers/repository-created.test.js
+++ b/test/integration/triggers/repository-created.test.js
@@ -14,19 +14,21 @@ describe('repository.created trigger', function () {
     teardownNock(githubScope)
   })
 
-  it('does not apply configuration when the repository does not have a settings.yml', async () => {
-    githubScope
-      .get(`/repos/${repository.owner.name}/${repository.name}/contents/${encodeURIComponent(Settings.FILE_NAME)}`)
-      .reply(NOT_FOUND, {
-        message: 'Not Found',
-        documentation_url: 'https://developer.github.com/v3/repos/contents/#get-contents'
-      })
-    githubScope
-      .get(`/repos/${repository.owner.name}/.github/contents/${encodeURIComponent(Settings.FILE_NAME)}`)
-      .reply(NOT_FOUND, {
-        message: 'Not Found',
-        documentation_url: 'https://developer.github.com/v3/repos/contents/#get-contents'
-      })
+  it('does not apply configuration when the repository has neither a settings.yml nor a settings.yaml', async () => {
+    for (const fileName of Settings.FILE_NAMES) {
+      githubScope
+        .get(`/repos/${repository.owner.name}/${repository.name}/contents/${encodeURIComponent(fileName)}`)
+        .reply(NOT_FOUND, {
+          message: 'Not Found',
+          documentation_url: 'https://developer.github.com/v3/repos/contents/#get-contents'
+        })
+      githubScope
+        .get(`/repos/${repository.owner.name}/.github/contents/${encodeURIComponent(fileName)}`)
+        .reply(NOT_FOUND, {
+          message: 'Not Found',
+          documentation_url: 'https://developer.github.com/v3/repos/contents/#get-contents'
+        })
+    }
 
     await probot.receive(buildRepositoryCreatedEvent())
   })

--- a/test/integration/triggers/repository-edited.test.js
+++ b/test/integration/triggers/repository-edited.test.js
@@ -24,19 +24,21 @@ describe('repository.edited trigger', function () {
     })
   })
 
-  it('does not apply configuration when the repository does not have a settings.yml', async () => {
-    githubScope
-      .get(`/repos/${repository.owner.name}/${repository.name}/contents/${encodeURIComponent(Settings.FILE_NAME)}`)
-      .reply(NOT_FOUND, {
-        message: 'Not Found',
-        documentation_url: 'https://developer.github.com/v3/repos/contents/#get-contents'
-      })
-    githubScope
-      .get(`/repos/${repository.owner.name}/.github/contents/${encodeURIComponent(Settings.FILE_NAME)}`)
-      .reply(NOT_FOUND, {
-        message: 'Not Found',
-        documentation_url: 'https://developer.github.com/v3/repos/contents/#get-contents'
-      })
+  it('does not apply configuration when the repository has neither a settings.yml nor a settings.yaml', async () => {
+    for (const fileName of Settings.FILE_NAMES) {
+      githubScope
+        .get(`/repos/${repository.owner.name}/${repository.name}/contents/${encodeURIComponent(fileName)}`)
+        .reply(NOT_FOUND, {
+          message: 'Not Found',
+          documentation_url: 'https://developer.github.com/v3/repos/contents/#get-contents'
+        })
+      githubScope
+        .get(`/repos/${repository.owner.name}/.github/contents/${encodeURIComponent(fileName)}`)
+        .reply(NOT_FOUND, {
+          message: 'Not Found',
+          documentation_url: 'https://developer.github.com/v3/repos/contents/#get-contents'
+        })
+    }
 
     await probot.receive(buildRepositoryEditedEvent())
   })

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -44,13 +44,27 @@ describe('plugin', () => {
     }
     sync = jest.fn()
 
-    plugin(app, {}, { sync, FILE_NAME: '.github/settings.yml' })
+    plugin(app, {}, { sync, FILE_NAMES: ['.github/settings.yml', '.github/settings.yaml'] })
   })
 
   describe('with settings modified on master', () => {
     it('syncs settings', async () => {
       await app.receive(event)
       expect(configGet).toHaveBeenCalledWith(expect.objectContaining({ path: '.github/settings.yml' }))
+      expect(sync).toHaveBeenCalled()
+    })
+  })
+
+  describe('with settings.yaml modified on master', () => {
+    beforeEach(() => {
+      event.payload = JSON.parse(JSON.stringify(pushSettings))
+      event.payload.ref = 'refs/heads/master'
+      event.payload.commits[0].added = ['.github/settings.yaml']
+      event.payload.head_commit.added = ['.github/settings.yaml']
+    })
+
+    it('syncs settings', async () => {
+      await app.receive(event)
       expect(sync).toHaveBeenCalled()
     })
   })
@@ -108,6 +122,38 @@ describe('plugin', () => {
     it('does sync settings', async () => {
       await app.receive(event)
       expect(sync).toHaveBeenCalled()
+    })
+
+    describe('when settings.yml does not exist', () => {
+      const yamlConfig = { repository: { name: any.word() } }
+
+      beforeEach(() => {
+        configGet
+          .mockResolvedValueOnce({ config: null, files: [{ config: null }] })
+          .mockResolvedValueOnce({ config: yamlConfig, files: [{ config: yamlConfig }] })
+      })
+
+      it('falls back to settings.yaml', async () => {
+        await app.receive(event)
+
+        expect(configGet).toHaveBeenCalledTimes(2)
+        expect(configGet).toHaveBeenNthCalledWith(1, expect.objectContaining({ path: '.github/settings.yml' }))
+        expect(configGet).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '.github/settings.yaml' }))
+        expect(sync).toHaveBeenCalledWith(expect.anything(), expect.anything(), yamlConfig)
+      })
+    })
+
+    describe('when neither settings.yml nor settings.yaml exists', () => {
+      beforeEach(() => {
+        configGet.mockResolvedValue({ config: null, files: [{ config: null }] })
+      })
+
+      it('syncs with an empty config', async () => {
+        await app.receive(event)
+
+        expect(configGet).toHaveBeenCalledTimes(2)
+        expect(sync).toHaveBeenCalledWith(expect.anything(), expect.anything(), {})
+      })
     })
   })
 })

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -1,4 +1,4 @@
-import { Probot, ProbotOctokit } from 'probot'
+import { Probot } from 'probot'
 import any from '@travi/any'
 import plugin from '../../index.js'
 import { readFileSync } from 'fs'
@@ -9,17 +9,25 @@ const pushReadme = JSON.parse(readFileSync(new URL('../fixtures/events/push.read
 const repositoryEdited = JSON.parse(readFileSync(new URL('../fixtures/events/repository.edited.json', import.meta.url)))
 
 describe('plugin', () => {
-  let app, event, sync
+  let app, event, sync, configGet
 
   beforeEach(() => {
+    configGet = jest.fn().mockResolvedValue({ config: {}, files: [{ config: {} }] })
+
     class Octokit {
       static defaults () {
-        return ProbotOctokit
+        return Octokit
       }
 
       constructor () {
         this.config = {
-          get: jest.fn().mockReturnValue({})
+          get: configGet
+        }
+        this.hook = {
+          before: () => {},
+          after: () => {},
+          error: () => {},
+          wrap: () => {}
         }
       }
 
@@ -42,6 +50,7 @@ describe('plugin', () => {
   describe('with settings modified on master', () => {
     it('syncs settings', async () => {
       await app.receive(event)
+      expect(configGet).toHaveBeenCalledWith(expect.objectContaining({ path: '.github/settings.yml' }))
       expect(sync).toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
This pull request

- [x] allows the `.yaml` extension for the settings file

❗️ Blocked by #1377.

Fixes #773.
Related to #213.
Related to probot/probot#422.
Related to probot/probot#1162.


