### PR TITLE
test: intercept config lookups in the unit test `Octokit` mock

### DIFF
--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -1,4 +1,4 @@
-import { Probot, ProbotOctokit } from 'probot'
+import { Probot } from 'probot'
 import any from '@travi/any'
 import plugin from '../../index.js'
 import { readFileSync } from 'fs'
@@ -9,17 +9,25 @@ const pushReadme = JSON.parse(readFileSync(new URL('../fixtures/events/push.read
 const repositoryEdited = JSON.parse(readFileSync(new URL('../fixtures/events/repository.edited.json', import.meta.url)))
 
 describe('plugin', () => {
-  let app, event, sync
+  let app, event, sync, configGet
 
   beforeEach(() => {
+    configGet = jest.fn().mockResolvedValue({ config: {}, files: [{ config: {} }] })
+
     class Octokit {
       static defaults () {
-        return ProbotOctokit
+        return Octokit
       }
 
       constructor () {
         this.config = {
-          get: jest.fn().mockReturnValue({})
+          get: configGet
+        }
+        this.hook = {
+          before: () => {},
+          after: () => {},
+          error: () => {},
+          wrap: () => {}
         }
       }
 
@@ -42,6 +50,7 @@ describe('plugin', () => {
   describe('with settings modified on master', () => {
     it('syncs settings', async () => {
       await app.receive(event)
+      expect(configGet).toHaveBeenCalledWith(expect.objectContaining({ path: '.github/settings.yml' }))
       expect(sync).toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
This pull request

- [x] intercepts config lookups in the unit test `Octokit` mock

The suite's `Octokit` mock declares a `config.get` stub, but its static `defaults()` returns the real `ProbotOctokit` — and Probot instantiates the class `defaults()` returns. So every context carried a real `Octokit`, the stubbed `config.get` was never called, and the unit tests exercised the real config plugin, which issues actual HTTP requests to `api.github.com`. The tests pass today only because an unauthenticated 404 happens to behave like "no config found"; a rate-limited 403 would throw instead.

With `defaults()` returning the mock class itself (plus the `hook` stub Probot requires), the stub is actually used: `config.get` resolves the `{ config, files }` shape the plugin returns, the suite runs hermetically offline, and a new assertion locks in that the `.github/settings.yml` lookup goes through the mock.

This is preparatory for a follow-up that adds `.github/settings.yaml` fallback support — asserting the file lookup order is only possible when the mock actually intercepts.

❗️ Blocks #1376.
