### PR TITLE
feat: allow enabling/disabling immutable releases for repos

### DIFF
--- a/docs/plugins/repository.md
+++ b/docs/plugins/repository.md
@@ -60,4 +60,8 @@ repository:
   # Either `true` to enable vulnerability alerts, or `false` to disable
   # vulnerability alerts.
   enable_vulnerability_alerts: true
+
+  # Either `true` to enable release immutability, or `false` to disable
+  # release immutability.
+  enable_immutable_releases: true
 ```

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -30,6 +30,19 @@ const enableVulnerabilityAlerts = ({ github, settings, enabled }) => {
   })
 }
 
+const enableImmutableReleases = ({ github, settings, enabled }) => {
+  if (enabled === undefined) {
+    return Promise.resolve()
+  }
+
+  const verb = enabled ? 'PUT' : 'DELETE'
+
+  return github.request(`${verb} /repos/{owner}/{repo}/immutable-releases`, {
+    owner: settings.owner,
+    repo: settings.repo,
+  })
+}
+
 export default class Repository {
   constructor (github, repo, settings) {
     this.github = github
@@ -42,6 +55,9 @@ export default class Repository {
 
     this.enableAutomatedSecurityFixes = this.settings.enable_automated_security_fixes
     delete this.settings.enable_automated_security_fixes
+
+    this.enableImmutableReleases = this.settings.enable_immutable_releases
+    delete this.settings.enable_immutable_releases
   }
 
   async sync () {
@@ -62,5 +78,6 @@ export default class Repository {
 
     await enableVulnerabilityAlerts({ enabled: this.enableVulnerabilityAlerts, ...this })
     await enableAutomatedSecurityFixes({ enabled: this.enableAutomatedSecurityFixes, ...this })
+    await enableImmutableReleases({ enabled: this.enableImmutableReleases, ...this })
   }
 }

--- a/test/integration/features/step_definitions/repository-steps.js
+++ b/test/integration/features/step_definitions/repository-steps.js
@@ -115,6 +115,35 @@ Given('security fixes are {string} in the config', async function (enablement) {
   )
 })
 
+Given('immutable releases are {string} in the config', async function (enablement) {
+  this.repository = {
+    name: repository.name,
+    enable_immutable_releases: enablement === 'enabled'
+  }
+
+  this.server.use(
+    http.get(
+      `https://api.github.com/repos/${repository.owner.name}/${repository.name}/contents/${encodeURIComponent(
+        settings.FILE_NAME
+      )}`,
+      () => HttpResponse.text(dump({ repository: this.repository }))
+    ),
+    http.patch(`https://api.github.com/repos/${repository.owner.name}/${repository.name}`, async ({ request }) => {
+      return new HttpResponse(null, { status: StatusCodes.OK })
+    }),
+    http[this.repository.enable_immutable_releases ? 'put' : 'delete'](
+      `https://api.github.com/repos/${repository.owner.name}/${repository.name}/immutable-releases`,
+      async () => {
+        this.immutableReleasesEnablement = enablement
+
+        return new HttpResponse(null, {
+          status: this.repository.enable_immutable_releases ? StatusCodes.OK : StatusCodes.NO_CONTENT
+        })
+      }
+    )
+  )
+})
+
 Then('the repository will be configured', async function () {
   assert.deepEqual(this.repositoryDetails, this.repository)
 })
@@ -129,4 +158,8 @@ Then('vulnerability alerts are {string}', async function (enablement) {
 
 Then('security fixes are {string}', async function (enablement) {
   assert.equal(this.securityFixesEnablement, enablement)
+})
+
+Then('immutable releases are {string}', async function (enablement) {
+  assert.equal(this.immutableReleasesEnablement, enablement)
 })

--- a/test/unit/lib/plugins/repository.test.js
+++ b/test/unit/lib/plugins/repository.test.js
@@ -131,7 +131,7 @@ describe('Repository', () => {
         })
       })
 
-      it('enables vulerability alerts when set to true', () => {
+      it('enables automated security fixes when set to true', () => {
         const plugin = configure({
           enable_automated_security_fixes: true
         })
@@ -147,7 +147,7 @@ describe('Repository', () => {
         })
       })
 
-      it('disables vulnerability alerts when set to false', async () => {
+      it('disables automated security fixes when set to false', async () => {
         const plugin = configure({
           enable_automated_security_fixes: false
         })
@@ -160,6 +160,47 @@ describe('Repository', () => {
           mediaType: {
             previews: ['london']
           }
+        })
+      })
+    })
+
+    describe('immutable releases', () => {
+      it('it skips if not set', async () => {
+        const plugin = configure({
+          enable_immutable_releases: undefined
+        })
+
+        await plugin.sync()
+
+        expect(github.request).not.toHaveBeenCalledWith('PUT /repos/{owner}/{repo}/immutable-releases', {
+          owner: repoOwner,
+          repo: repoName,
+        })
+      })
+
+      it('enables immutable releases when set to true', () => {
+        const plugin = configure({
+          enable_immutable_releases: true
+        })
+
+        return plugin.sync().then(() => {
+          expect(github.request).toHaveBeenCalledWith('PUT /repos/{owner}/{repo}/immutable-releases', {
+            owner: repoOwner,
+            repo: repoName,
+          })
+        })
+      })
+
+      it('disables immutable releases when set to false', async () => {
+        const plugin = configure({
+          enable_immutable_releases: false
+        })
+
+        await plugin.sync()
+
+        expect(github.request).toHaveBeenCalledWith('DELETE /repos/{owner}/{repo}/immutable-releases', {
+          owner: repoOwner,
+          repo: repoName,
         })
       })
     })


### PR DESCRIPTION
Provides support for GitHub's [Immutable Releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) feature.

Example config:

```yaml
# .github/settings.yml

repository:
  enable_immutable_releases: true
```